### PR TITLE
pull out _getTileURL (for extending) and added _getZoomForURL

### DIFF
--- a/src/Leaflet.VectorGrid.Protobuf.js
+++ b/src/Leaflet.VectorGrid.Protobuf.js
@@ -5,6 +5,8 @@ L.VectorGrid.Protobuf = L.VectorGrid.extend({
 
 	options: {
 		subdomains: 'abc',	// Like L.TileLayer
+		zoomOffset: 0, // Like L.TileLayer
+		maxNativeZoom: null // Like L.TileLayer
 	},
 
 
@@ -18,15 +20,8 @@ L.VectorGrid.Protobuf = L.VectorGrid.extend({
 
 	_getSubdomain: L.TileLayer.prototype._getSubdomain,
 
-
 	_getVectorTilePromise: function(coords) {
-		var tileUrl = L.Util.template(this._url, L.extend({
-			s: this._getSubdomain(coords),
-			x: coords.x,
-			y: coords.y,
-			z: coords.z
-// 			z: this._getZoomForUrl()	/// TODO: Maybe replicate TileLayer's maxNativeZoom
-		}, this.options));
+		var tileUrl = this._getTileUrl(coords);
 
 		return fetch(tileUrl).then(function(response){
 
@@ -71,6 +66,28 @@ L.VectorGrid.Protobuf = L.VectorGrid.extend({
 
 			return json;
 		});
+	},
+
+	_getTileUrl: function (coords) {
+		return L.Util.template(this._url, L.extend({
+			s: this._getSubdomain(coords),
+			x: coords.x,
+			y: coords.y,
+			z: this._getZoomForUrl(coords.z)
+		}, this.options));
+	},
+
+	_getZoomForUrl: function (zoom) {
+
+		var options = this.options;
+
+		if (options.zoomReverse) {
+			zoom = options.maxZoom - zoom;
+		}
+
+		zoom += options.zoomOffset;
+
+		return options.maxNativeZoom !== null ? Math.min(zoom, options.maxNativeZoom) : zoom;
 	}
 });
 
@@ -78,4 +95,3 @@ L.VectorGrid.Protobuf = L.VectorGrid.extend({
 L.vectorGrid.protobuf = function (url, options) {
 	return new L.VectorGrid.Protobuf(url, options);
 };
-


### PR DESCRIPTION
This PR pulls out the L.Util.Template call into its own _getTileURL function as well as implemented the TODO of using the _getZoomForURL.

This would allow a developer to extend the L.VectorGrid.Protobuf class and generate their own tile URL without having to follow the URL skeleton scheme or re-implementing the entire _getVectorTilePromise function.

If there are any changes to the code, or if this doesn't fit into the project, just let me know.

Thanks!
