### PR TITLE
Remember overridden styles between draw calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 * Refactored the code modules into ES6 modules
 * Switched the build system and dependencies to use RollupJS
+* Store styles set through `setFeatureStyle` so the changes persist after zooming/panning
 
 ## 1.1.0
 


### PR DESCRIPTION
Stores any styles set with `setFeatureStyle` between calls to `createTile`, so that a feature preserves its set style even when zooming and panning.

Close #33.