### PR TITLE
Address setFeatureStyle quirks

### DIFF
--- a/src/Leaflet.VectorGrid.js
+++ b/src/Leaflet.VectorGrid.js
@@ -52,7 +52,11 @@ L.VectorGrid = L.GridLayer.extend({
 						id = this.options.getFeatureId(feat);
 						var styleOverride = this._overriddenStyles[id];
 						if (styleOverride) {
-							styleOptions = styleOverride[layerName];
+							if (styleOverride[layerName]) {
+								styleOptions = styleOverride[layerName];
+							} else {
+								styleOptions = styleOverride;
+							}
 						}
 					}
 
@@ -97,18 +101,25 @@ L.VectorGrid = L.GridLayer.extend({
 	},
 
 	setFeatureStyle: function(id, layerStyle) {
-		var styleOverride = this._overriddenStyles[id] = {}
+		this._overriddenStyles[id] = {}
 
 		for (var tileKey in this._vectorTiles) {
 			var tile = this._vectorTiles[tileKey];
 			var features = tile._features;
 			var data = features[id];
 			if (data) {
-				styleOverride[data.layerName] = layerStyle;
+				this._overriddenStyles[id] = layerStyle;
 				var feat = data.feature;
-				var styleOptions = (layerStyle instanceof Function) ?
-				layerStyle(feat.properties, tile.getCoord().z) :
-				layerStyle;
+
+				var styleOptions = layerStyle;
+				if (layerStyle[data.layerName]) {
+					styleOptions = layerStyle[data.layerName];
+				}
+
+				styleOptions = (styleOptions instanceof Function) ?
+					styleOptions(feat.properties, tile.getCoord().z) :
+					styleOptions;
+
 				this._updateStyles(feat, tile, styleOptions);
 			}
 		}

--- a/src/Leaflet.VectorGrid.js
+++ b/src/Leaflet.VectorGrid.js
@@ -121,6 +121,8 @@ L.VectorGrid = L.GridLayer.extend({
 					styleOptions;
 
 				this._updateStyles(feat, tile, styleOptions);
+			} else {
+				this._overriddenStyles[id] = layerStyle;
 			}
 		}
 	},


### PR DESCRIPTION
This pull request addresses issues that I documented in #40 and #41, namely:
- **`setFeatureStyle` now remembers overridden styles, even if the tiles haven't finished loading in yet**
Before, calling `setFeatureStyle` when tiles haven't finished loading would cause features in those tiles to lose all styling (i.e. leaflet default style, not default style you specified). This PR fixes this quirk so now `setFeatureStyle` will remember feature IDs you pass in and apply them to tiles as they load.

- **`setFeatureStyle` now accepts named layers**
Before, `setFeatureStyle` only accepted an `L.Path` options object, or an array of these. This got applied to every single named layer. This PR amends this so now you can pass in a set of options, similar to how initializing a VectorGrid with `vectorTileLayerStyles`. **This shouldn't be a breaking change, since the original `L.Path` objects still work in addition to sets of options.**

Thanks!
