### PR TITLE
Add support for styling points witch icons

### DIFF
--- a/demo/demo-points-icons.html
+++ b/demo/demo-points-icons.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Leaflet.VectorGrid Points Example</title>
+	<meta charset="utf-8" />
+
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.2/dist/leaflet.css" />
+	<script src="https://unpkg.com/leaflet@1.0.2/dist/leaflet.js"></script>
+	<script src="../dist/Leaflet.VectorGrid.bundled.js"></script>
+</head>
+<body style='margin:0'>
+	<div id="map" style="width: 100vw; height: 100vh"></div>
+
+
+<!--	<script type="text/javascript" src="../vendor/pbf-dev.js"></script>
+	<script type="text/javascript" src="../vendor/vector-tile-dev.js"></script>
+
+	<script type="text/javascript" src="../src/Leaflet.Renderer.SVG.Tile.js"></script>
+	<script type="text/javascript" src="../src/Leaflet.Renderer.Canvas.Tile.js"></script>
+	<script type="text/javascript" src="../src/Leaflet.VectorGrid.js"></script>
+	<script type="text/javascript" src="../src/Leaflet.VectorGrid.Protobuf.js"></script>-->
+
+	<script>
+
+		var map = L.map('map');
+
+// 		var cartodbAttribution = '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>';
+//
+// 		var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png', {
+// 			attribution: cartodbAttribution,
+// 			opacity: 0.5
+// 		}).addTo(map);
+
+
+		var url = 'https://{s}.tiles.mapbox.com/v4/mapbox.mapbox-streets-v6/{z}/{x}/{y}.vector.pbf?access_token=pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpandmbXliNDBjZWd2M2x6bDk3c2ZtOTkifQ._QA7i5Mpkd_m30IGElHziw';
+
+		var vectorTileOptions = {
+			rendererFactory: L.canvas.tile,
+			attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://www.mapbox.com/about/maps/">MapBox</a>',
+			vectorTileLayerStyles: {
+				'poi_label': { icon: new L.Icon.Default() },
+				water: [],
+				country_label: [],
+				marine_label: [],
+				state_label: [],
+				place_label: [],
+				waterway_label: [],
+				landuse: [],
+				landuse_overlay: [],
+				road: [],
+				waterway: [],
+				aeroway: [],
+				tunnel: [],
+				bridge: [],
+				barrier_line: [],
+				building: [],
+				road_label: [],
+				housenum_label: [],
+				water_label: []
+			},
+			interactive: true,	// Make sure that this VectorGrid fires mouse/pointer events
+			getFeatureId: function(f) {
+				return f.properties.osm_id;
+			}
+		};
+
+		L.tileLayer('http://tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map);
+
+		var pbfLayer = L.vectorGrid.protobuf(url, vectorTileOptions)
+			.on('click', function(e) {	// The .on method attaches an event handler
+				L.popup()
+					.setContent(e.layer.properties.name || e.layer.properties.type)
+					.setLatLng(e.latlng)
+					.openOn(map);
+
+				L.DomEvent.stop(e);
+			})
+			.addTo(map);
+
+		map.setView([40.9994639, -74.163208], 15);
+	</script>
+</body>
+</html>

--- a/src/Leaflet.Renderer.Canvas.Tile.js
+++ b/src/Leaflet.Renderer.Canvas.Tile.js
@@ -16,7 +16,7 @@ L.Canvas.Tile = L.Canvas.extend({
 
 		if (options.interactive) {
 			// By default, Leaflet tiles do not have pointer events
-		    this._container.style.pointerEvents = 'auto';
+			this._container.style.pointerEvents = 'auto';
 		}
 	},
 
@@ -64,6 +64,29 @@ L.Canvas.Tile = L.Canvas.extend({
 	/// TODO: Modify _initPath to include an extra parameter, a group name
 	/// to order symbolizers by z-index
 
+	_updateIcon: function (layer) {
+		if (!this._drawing) { return; }
+
+		var icon = layer.options.icon,
+		    options = icon.options,
+		    size = L.point(options.iconSize),
+		    anchor = options.iconAnchor ||
+		        	 size && size.divideBy(2, true),
+		    p = layer._point.subtract(anchor),
+		    ctx = this._ctx,
+		    img = layer._getImage(),
+		    size = img.size;
+
+		if (img.image.complete) {
+			ctx.drawImage(img.image, p.x, p.y, size.x, size.y);
+		} else {
+			L.DomEvent.on(img, 'load', function() {
+				ctx.drawImage(img.image, p.x, p.y, size.x, size.y);
+			});
+		}
+
+		this._drawnLayers[layer._leaflet_id] = layer;
+	}
 });
 
 

--- a/src/Leaflet.Renderer.SVG.Tile.js
+++ b/src/Leaflet.Renderer.SVG.Tile.js
@@ -14,7 +14,7 @@ L.SVG.Tile = L.SVG.extend({
 
 		if (options.interactive) {
 			// By default, Leaflet tiles do not have pointer events
-		    this._container.style.pointerEvents = 'auto';
+			this._container.style.pointerEvents = 'auto';
 		}
 		this._layers = {};
 	},
@@ -52,6 +52,20 @@ L.SVG.Tile = L.SVG.extend({
 		this._layers[L.stamp(layer)] = layer;
 	},
 
+	_updateIcon: function (layer) {
+		var path = layer._path = L.SVG.create('image'),
+		    icon = layer.options.icon,
+		    options = icon.options,
+		    size = L.point(options.iconSize),
+		    anchor = options.iconAnchor ||
+		        	 size && size.divideBy(2, true),
+		    p = layer._point.subtract(anchor);
+		path.setAttribute('x', p.x);
+		path.setAttribute('y', p.y);
+		path.setAttribute('width', size.x + 'px');
+		path.setAttribute('height', size.y + 'px');
+		path.setAttribute('href', options.iconUrl);
+	}
 });
 
 


### PR DESCRIPTION
This PR adds support for styling point features using a new option, `icon`, which works similar to using a marker, as requested in #30.