### PR TITLE
Fix race condition. If layer this._map is null, do not render new tiles

### DIFF
--- a/src/Leaflet.VectorGrid.js
+++ b/src/Leaflet.VectorGrid.js
@@ -93,7 +93,9 @@ L.VectorGrid = L.GridLayer.extend({
 				}
 
 			}
-			renderer.addTo(this._map);
+			if (this._map != null) {
+				renderer.addTo(this._map);
+			}
 			L.Util.requestAnimFrame(done.bind(coords, null, null));
 		}.bind(this));
 


### PR DESCRIPTION
Fixes the problem that happens when a layer is removed from the map while there is still pending work (on a webworker) that is prepared to trigger an addTile.