### PR TITLE
Use default radius for points unless specified

### DIFF
--- a/src/Leaflet.VectorGrid.js
+++ b/src/Leaflet.VectorGrid.js
@@ -231,7 +231,7 @@ var PointLayer = L.CircleMarker.extend({
 
 	render: function(renderer, style) {
 		FeatureLayer.prototype.render.call(this, renderer, style);
-		this._radius = style.radius;
+		this._radius = style.radius || L.CircleMarker.prototype.options.radius;
 		this._updatePath();
 	},
 


### PR DESCRIPTION
Other features get Leaflet's default style unless you specifically specify a style. Points, however, become invisible until you specify a `radius` style, so they're not styled by default, which I think is counter intuitive. 