### PR TITLE
Add a hook to be notified when point features are added

### DIFF
--- a/demo/demo-labels.html
+++ b/demo/demo-labels.html
@@ -45,14 +45,13 @@
 		var vectorTileOptions = {
 			rendererFactory: L.canvas.tile,
 			attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://www.mapbox.com/about/maps/">MapBox</a>',
-			pointFeatureHooks: {
-				place_label: function(properties, tileCoords, point) {
-					if(properties.localrank > 60) {
-						marker = new L.Marker(map.unproject(point));
-						marker.bindTooltip(properties.name).openTooltip();
-						map.addLayer(marker);
-						setMarkerToCache(tileCoords, marker);
-					}
+			onEachFeature: function(feature, featureLayer, vtLayer, tileCoords) {
+				if(vtLayer.name === 'place_label' && feature.properties.localrank > 60) {
+					var latlng = this.vtGeometryToLatLng(feature.geometry[0], vtLayer, tileCoords)
+					marker = new L.Marker(latlng);
+					marker.bindTooltip(feature.properties.name).openTooltip();
+					map.addLayer(marker);
+					setMarkerToCache(tileCoords, marker);
 				}
 			},
 			vectorTileLayerStyles: {

--- a/demo/demo-labels.html
+++ b/demo/demo-labels.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Leaflet Map Panes Example</title>
+	<meta charset="utf-8" />
+
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.2/dist/leaflet.css" />
+	<script src="https://unpkg.com/leaflet@1.0.2/dist/leaflet.js"></script>
+	<script src="http://localhost:4567/Leaflet.VectorGrid.bundled.js"></script>
+</head>
+<body style='margin:0'>
+	<div id="map" style="width: 100vw; height: 100vh"></div>
+
+	<script>
+
+		var map = L.map('map');
+
+		var url = 'https://{s}.tiles.mapbox.com/v4/mapbox.mapbox-streets-v6/{z}/{x}/{y}.vector.pbf?access_token=pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpandmbXliNDBjZWd2M2x6bDk3c2ZtOTkifQ._QA7i5Mpkd_m30IGElHziw';
+
+		// Keep references of the markers created on a tile so that they can be
+		// removed when the tile is unloaded
+		function tileCoordsToKey(coords) {
+      return coords.x + ':' + coords.y + ':' + coords.z;
+    }
+		var markersCache = {}
+		function setMarkerToCache(tileCoords, marker) {
+			var tileKey = tileCoordsToKey(tileCoords);
+			markersCache[tileKey] = markersCache[tileKey] || [];
+			markersCache[tileKey].push(marker);
+		}
+		function clearTileMarkers(tileCoords) {
+			var tileKey = tileCoordsToKey(tileCoords);
+			var markers = markersCache[tileKey]
+			if (!markers) {
+				return;
+			}
+			for(var i = 0; i < markers.length; i++) {
+				map.removeLayer(markers[i]);
+			}
+			delete markersCache[tileKey];
+		}
+
+		var vectorTileOptions = {
+			rendererFactory: L.canvas.tile,
+			attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://www.mapbox.com/about/maps/">MapBox</a>',
+			pointFeatureHooks: {
+				place_label: function(properties, tileCoords, point) {
+					if(properties.localrank > 60) {
+						marker = new L.Marker(map.unproject(point));
+						marker.bindTooltip(properties.name).openTooltip();
+						map.addLayer(marker);
+						setMarkerToCache(tileCoords, marker);
+					}
+				}
+			},
+			vectorTileLayerStyles: {
+
+				water: {
+					weight: 0,
+					fillColor: '#9bc2c4',
+					fillOpacity: 1,
+					fill: true,
+					stroke: false
+				},
+
+				admin: [],
+				state_label: [],
+				country_label: [],
+				marine_label: [],
+				state_label: [],
+				place_label: function(properties) {
+					if(properties.localrank > 60) {
+						return {};
+					} else {
+						return [];
+					}
+				},
+				waterway_label: [],
+				landuse: [],
+				landuse_overlay: [],
+				road: [],
+				poi_label: [],
+				waterway: [],
+				aeroway: [],
+				tunnel: [],
+				bridge: [],
+				barrier_line: [],
+				building: [],
+				road_label: [],
+				housenum_label: [],
+
+			}
+		};
+
+		var pbfLayer = L.vectorGrid.protobuf(url, vectorTileOptions).addTo(map);
+		pbfLayer.on('tileunload', function(e) {
+			clearTileMarkers(e.coords);
+		})
+
+		map.setView({ lat: 47.040182144806664, lng: 9.667968750000002 }, 6);
+
+
+	</script>
+</body>
+</html>

--- a/demo/demo-labels.html
+++ b/demo/demo-labels.html
@@ -19,29 +19,6 @@
 
 		var url = 'https://{s}.tiles.mapbox.com/v4/mapbox.mapbox-streets-v6/{z}/{x}/{y}.vector.pbf?access_token=pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpandmbXliNDBjZWd2M2x6bDk3c2ZtOTkifQ._QA7i5Mpkd_m30IGElHziw';
 
-		// Keep references of the markers created on a tile so that they can be
-		// removed when the tile is unloaded
-		function tileCoordsToKey(coords) {
-      return coords.x + ':' + coords.y + ':' + coords.z;
-    }
-		var markersCache = {}
-		function setMarkerToCache(tileCoords, marker) {
-			var tileKey = tileCoordsToKey(tileCoords);
-			markersCache[tileKey] = markersCache[tileKey] || [];
-			markersCache[tileKey].push(marker);
-		}
-		function clearTileMarkers(tileCoords) {
-			var tileKey = tileCoordsToKey(tileCoords);
-			var markers = markersCache[tileKey]
-			if (!markers) {
-				return;
-			}
-			for(var i = 0; i < markers.length; i++) {
-				map.removeLayer(markers[i]);
-			}
-			delete markersCache[tileKey];
-		}
-
 		var vectorTileOptions = {
 			rendererFactory: L.canvas.tile,
 			attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://www.mapbox.com/about/maps/">MapBox</a>',
@@ -50,8 +27,7 @@
 					var latlng = this.vtGeometryToLatLng(feature.geometry[0], vtLayer, tileCoords)
 					marker = new L.Marker(latlng);
 					marker.bindTooltip(feature.properties.name).openTooltip();
-					map.addLayer(marker);
-					setMarkerToCache(tileCoords, marker);
+					this.addUserLayer(marker, tileCoords);
 				}
 			},
 			vectorTileLayerStyles: {
@@ -94,9 +70,6 @@
 		};
 
 		var pbfLayer = L.vectorGrid.protobuf(url, vectorTileOptions).addTo(map);
-		pbfLayer.on('tileunload', function(e) {
-			clearTileMarkers(e.coords);
-		})
 
 		map.setView({ lat: 47.040182144806664, lng: 9.667968750000002 }, 6);
 


### PR DESCRIPTION
This solves https://github.com/Leaflet/Leaflet.VectorGrid/issues/67

The demo is very explicit I think. The user can define a function for each vt layer to be called when a point feature is added. This function will receive the feature's properties, the tile coordinates and a point. Enough information to draw a marker on the map for example.

The demo also includes a cache to clear markers when the tiles are unloaded. It is a bit verbose. Maybe VectorGrid could implement this cache of user defined layers (the return of the hook function for example) for a smoother integration.

I didn't write the documentation yet, I wanted to get some feedback before. I suppose that it should include a warning about performance because many vector tiles layers are too dense for this feature to be a good idea.