### PR TITLE
Clean up map's interactive targets when tiles are removed.

### DIFF
--- a/src/Leaflet.Renderer.Canvas.Tile.js
+++ b/src/Leaflet.Renderer.Canvas.Tile.js
@@ -38,6 +38,10 @@ L.Canvas.Tile = L.Canvas.extend({
 		this._map = map;
 	},
 
+	removeFrom: function (map) {
+		delete this._map;
+	},
+
 	_onClick: function (e) {
 		var point = this._map.mouseEventToLayerPoint(e).subtract(this.getOffset()), layers = [], layer;
 

--- a/src/Leaflet.Renderer.SVG.Tile.js
+++ b/src/Leaflet.Renderer.SVG.Tile.js
@@ -39,6 +39,16 @@ L.SVG.Tile = L.SVG.extend({
 		}
 	},
 
+	removeFrom: function (map) {
+		if (this.options.interactive) {
+			for (var i in this._layers) {
+				var layer = this._layers[i];
+				delete this._map._targets[L.stamp(layer._path)];
+			}
+		}
+		delete this._map;
+	},
+
 	_initContainer: function() {
 		L.SVG.prototype._initContainer.call(this);
 		var rect =  L.SVG.create('rect');

--- a/src/Leaflet.VectorGrid.js
+++ b/src/Leaflet.VectorGrid.js
@@ -15,7 +15,13 @@ L.VectorGrid = L.GridLayer.extend({
 			this._vectorTiles = {};
 			this._overriddenStyles = {};
 			this.on('tileunload', function(e) {
-				delete this._vectorTiles[this._tileCoordsToKey(e.coords)];
+				var key = this._tileCoordsToKey(e.coords),
+				    tile = this._vectorTiles[key];
+
+				if (tile && this._map) {
+					tile.removeFrom(this._map);
+				}
+				delete this._vectorTiles[key];
 			}, this);
 		}
 	},


### PR DESCRIPTION
Currently, all features ever created for any tile amass in the map's interactive targets, preventing garbage collection.

My solution only works when `VectorGrid` is recording created tiles (i.e. with the `getFeatureId` option), but at least it's better than nothing.

It is worth considering to record created tiles when `interactive` in order to be able to do this irrespective of the `getFeatureId` option.