### PR TITLE
Make features instead of tiles accept pointer events.

### DIFF
--- a/src/Leaflet.Renderer.SVG.Tile.js
+++ b/src/Leaflet.Renderer.SVG.Tile.js
@@ -12,10 +12,6 @@ L.SVG.Tile = L.SVG.extend({
 		this._container.setAttribute('height', this._size.y);
 		this._container.setAttribute('viewBox', [0, 0, this._size.x, this._size.y].join(' '));
 
-		if (options.interactive) {
-			// By default, Leaflet tiles do not have pointer events
-			this._container.style.pointerEvents = 'auto';
-		}
 		this._layers = {};
 	},
 
@@ -34,6 +30,8 @@ L.SVG.Tile = L.SVG.extend({
 		if (this.options.interactive) {
 			for (var i in this._layers) {
 				var layer = this._layers[i];
+				// By default, Leaflet tiles do not have pointer events.
+				layer._path.style.pointerEvents = 'auto';
 				this._map._targets[L.stamp(layer._path)] = layer;
 			}
 		}


### PR DESCRIPTION
If the layer is interactive, making the tiles accept pointer events makes it impossible to »click through« them if used as overlays. Making the features accept pointer events instead allows overlays to work as expected.

Note that the `path.leaflet-interactive` CSS rule does not apply because it is limited to SVGs that are direct descendants of a `.leaflet-pane`, while our SVG tiles live many levels down inside a `.leaflet-layer`. Changing the CSS rule to apply to all SVG `<path>` marked `.leaflet-interactive` underneath `.leaflet-pane` would avoid the need to manually set the `pointer-events` style on each `<path>`, but might have unintended effects which need to be investigated.