### PR TITLE
Canvas mouse fixes.

### DIFF
--- a/src/Leaflet.Renderer.Canvas.Tile.js
+++ b/src/Leaflet.Renderer.Canvas.Tile.js
@@ -43,17 +43,17 @@ L.Canvas.Tile = L.Canvas.extend({
 	},
 
 	_onClick: function (e) {
-		var point = this._map.mouseEventToLayerPoint(e).subtract(this.getOffset()), layers = [], layer;
+		var point = this._map.mouseEventToLayerPoint(e).subtract(this.getOffset()), layer, clickedLayer;
 
 		for (var id in this._layers) {
 			layer = this._layers[id];
 			if (layer.options.interactive && layer._containsPoint(point) && !this._map._draggableMoved(layer)) {
-				L.DomEvent._fakeStop(e);
-				layers.push(layer);
+				clickedLayer = layer;
 			}
 		}
-		if (layers.length)  {
-			this._fireEvent(layers, e);
+		if (clickedLayer)  {
+			L.DomEvent.fakeStop(e);
+			this._fireEvent([clickedLayer], e);
 		}
 	},
 

--- a/src/Leaflet.Renderer.Canvas.Tile.js
+++ b/src/Leaflet.Renderer.Canvas.Tile.js
@@ -61,7 +61,6 @@ L.Canvas.Tile = L.Canvas.extend({
 		if (!this._map || this._map.dragging.moving() || this._map._animatingZoom) { return; }
 
 		var point = this._map.mouseEventToLayerPoint(e).subtract(this.getOffset());
-		this._handleMouseOut(e, point);
 		this._handleMouseHover(e, point);
 	},
 


### PR DESCRIPTION
These commits implement some fixes that were done to Leaflet's `Canvas` renderer, but not applied to `VectorGrid`'s version.

They also fix an exception due to calling the non-existent `L.DomEvent._fakeStop()` method, which has been renamed to `fakeStop()`.