### PR TITLE
remove demo line from gobblefile.js

### DIFF
--- a/gobblefile.js
+++ b/gobblefile.js
@@ -110,8 +110,6 @@ var uglifiedBundledCode = src2uglified.transform('rollup', {
 });
 
 
-var demo = gobble('demo').moveTo('demo');
-
 var leafdoc = src.transform('leafdoc', {
 	templateDir: 'leafdoc-templates',
 	output: 'vectorgrid-api-docs.html',
@@ -132,7 +130,6 @@ module.exports = gobble([
 	uglifiedCode,       	// No extra deps,    minified
 	uglifiedBundledCode,	//    Extra deps,    minified
 
-// 	demo,
 // 	leaflet
 	leafdoc
 ]);


### PR DESCRIPTION
Since the `demo` directory no longer exists, the line I removed prevents gobble from running (so `npm start`) simlply errors

~Edit: Also fixes a clickHandler bug that uses the non-existent `L.DomEvent.fakeStop` instead of `L.DomEvent._fakeStop(e)`~