### PR TITLE
Add polyfill for fetch function in IE / Safari 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
   "dependencies": {
     "pbf": "^3.0.2",
     "topojson-client": "^2.1.0",
-    "vector-tile": "^1.3.0"
+    "vector-tile": "^1.3.0",
+    "whatwg-fetch": "^2.0.3"
   },
   "peerDependencies": {
     "leaflet": "^1.0.2"

--- a/src/bundle-extra.js
+++ b/src/bundle-extra.js
@@ -2,6 +2,8 @@
 // Aux file to bundle everything together, including the optional dependencies
 // for protobuf tiles
 
+import {} from 'whatwg-fetch'
+
 import {} from 'pbf';
 import {VectorTile} from 'vector-tile';
 


### PR DESCRIPTION
The `_getVectorTilePromise` method uses a native function 'fetch' to make ajax requests for tiles. This function is not supported in IE or Safari 10 and below. Adding this polyfill to the project expands its browser support.