### PR TITLE
Add whatwg-fetch polyfill in demo

### DIFF
--- a/docs/demo-geojson.html
+++ b/docs/demo-geojson.html
@@ -5,6 +5,10 @@
 	<meta charset="utf-8" />
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+	<!-- fetch polyfill for older browsers -->
+	<script src="https://unpkg.com/whatwg-fetch@2.0.3"></script>
+
 	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css" />
 	<script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet.js"></script>
 	<script src="https://unpkg.com/leaflet.vectorgrid@1.2.0"></script>

--- a/docs/demo-points-icons.html
+++ b/docs/demo-points-icons.html
@@ -6,6 +6,9 @@
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+	<!-- fetch polyfill for older browsers -->
+	<script src="https://unpkg.com/whatwg-fetch@2.0.3"></script>
+
 	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css" />
 	<script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet.js"></script>
 	<script src="https://unpkg.com/leaflet.vectorgrid@1.2.0"></script>

--- a/docs/demo-points.html
+++ b/docs/demo-points.html
@@ -6,11 +6,13 @@
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+	<!-- fetch polyfill for older browsers -->
+	<script src="https://unpkg.com/whatwg-fetch@2.0.3"></script>
+
 	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css" />
 	<script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet-src.js"></script>
 	<script src="https://unpkg.com/leaflet.vectorgrid@1.2.0"></script>
 <!-- 	<script type="text/javascript" src="../dist/Leaflet.VectorGrid.bundled.js"></script> -->
-</script>
 </head>
 <body style='margin:0'>
 	<div id="map" style="width: 100vw; height: 100vh"></div>

--- a/docs/demo-topojson.html
+++ b/docs/demo-topojson.html
@@ -5,6 +5,10 @@
 	<meta charset="utf-8" />
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+	<!-- fetch polyfill for older browsers -->
+	<script src="https://unpkg.com/whatwg-fetch@2.0.3"></script>
+
 	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css" />
 	<script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet.js"></script>
 	<script src="https://unpkg.com/leaflet.vectorgrid@1.2.0"></script>

--- a/docs/demo-vectortiles.html
+++ b/docs/demo-vectortiles.html
@@ -6,6 +6,9 @@
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+	<!-- fetch polyfill for older browsers -->
+	<script src="https://unpkg.com/whatwg-fetch@2.0.3"></script>
+
 	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css" />
 	<script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet.js"></script>
 	<script src="https://unpkg.com/leaflet.vectorgrid@1.2.0"></script>


### PR DESCRIPTION
Most of the demos should now be functional in fetch unsupported browsers (e.g. Safari 10).