### PR TITLE
Hardlink

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/gobblefile.js
+++ b/gobblefile.js
@@ -1,7 +1,7 @@
 
 
 var gobble = require('gobble');
-var src = gobble('src');
+var src = gobble('src').transform('hardlink');
 
 
 // Run rollup on the web worker code, in order to include GeoJSON-vt and TopoJSON into it.
@@ -44,8 +44,8 @@ var uglifiedWebWorker = src.transform('rollup', {
 });
 
 // Get the rolled-up worker code back next to the same directory as the main code
-var src2         = gobble([src, concatenatedWebWorker]);
-var src2uglified = gobble([src, uglifiedWebWorker]);
+var src2         = gobble([src, concatenatedWebWorker]).transform('hardlink');
+var src2uglified = gobble([src, uglifiedWebWorker]).transform('hardlink');
 
 
 // We'll run rollup four times, with slightly different options and using different

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "geojson-vt": "^2.2.0",
     "gobble": "^0.11.3",
     "gobble-cli": "^0.7.0",
+    "gobble-hardlink": "^0.2.0",
     "gobble-leafdoc": "^0.1.8",
     "gobble-rollup": "^0.36.0",
     "rollup-plugin-buble": "^0.14.0",


### PR DESCRIPTION
Fixed gobble rollup error under macos, it was not able to follow symlinks. I introduced a dev dependency [gobble-hardlink](https://github.com/gobblejs/gobble-hardlink) and transformed all file references using transform('hardlink')