### PR TITLE
IE support for Web Workers

### DIFF
--- a/src/Leaflet.VectorGrid.Slicer.js
+++ b/src/Leaflet.VectorGrid.Slicer.js
@@ -72,7 +72,7 @@ L.VectorGrid.Slicer = L.VectorGrid.extend({
 		}
 
 // 		this._worker = new Worker(window.URL.createObjectURL(new Blob([workerCode])));
-		this._worker = new Worker(workerCode);
+		this._worker = new Worker(options.workerUrl || workerCode);
 
 		// Send initial data to worker.
 		this._worker.postMessage(['slice', geojson, options]);


### PR DESCRIPTION
# The problem
IE Web Workers don't support BLOB URL's.

# This solution
https://github.com/Leaflet/Leaflet.VectorGrid/issues/58#issuecomment-315081394

This fix allows the user to place the Web Worker code in an external file then specify the path where they have made it available on their web server.

## Usage
```
L.vectorGrid.slicer(geoJson, {
    workerCode: '/path/to/Leaflet.VectorGrid/WebWorker.js',
    [...]
}).addTo(map);
```

# A better solution
The solution in this pull request requires the worker code to be stringified in the distributed code (as it currently is) and then the exact same code copied in an external file (for those who need to support IE).

A better approach would be to use a similar method to [ng-webworker](https://github.com/mattslocum/ng-webworker) whereby the external web worker is just a shell that executes whatever is passed to it. This way it avoids duplicating the code and the external web worker file size is a much smaller to download.

With this approach you keep the stringified worker in the distributed code (as it currently is) then pass the string in memory to the worker shell which just eval's it.

https://github.com/mattslocum/ng-webworker/blob/master/README.md (IE workarounds)

Worker shell example
https://github.com/mattslocum/ng-webworker/blob/master/src/worker_wrapper.js