### PR TITLE
Add basic travis support to at least verify it builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+    - "node"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Display gridded vector data (sliced GeoJSON or protobuf vector tiles) in Leaflet 1.0",
   "main": "dist/Leaflet.VectorGrid.bundled.min.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "exit 0",
     "prepublish": "node_modules/.bin/gobble build -f dist/",
     "build": "node_modules/.bin/gobble build -f dist/",
     "start": "node_modules/.bin/gobble"


### PR DESCRIPTION
From what I gather, this will really just verify that `npm install` (which is run implictly by Travis) will work, but that's not a bad start given that the build has broken quite often, historically.