### PR TITLE
Pass feature type into styleOptions, allow returned style array to contain functions

### DIFF
--- a/docs/vectorgrid-api-docs.html
+++ b/docs/vectorgrid-api-docs.html
@@ -386,9 +386,9 @@ Styling is done via per-layer² sets of <code>L.Path</code> options in the <code
             }
         },
         // A function for styling features dynamically, depending on their
-        // properties, the map&#39;s zoom level, and the layer's geometry type
-        // (point, line, polygon)
-        water: function(properties, zoom, type) {
+        // properties, the map&#39;s zoom level, and the layer's geometry
+        // dimension (point, line, polygon)
+        water: function(properties, zoom, geometry_dimension) {
             return [
                 {   // point
                     radius: 5,

--- a/docs/vectorgrid-api-docs.html
+++ b/docs/vectorgrid-api-docs.html
@@ -388,7 +388,7 @@ Styling is done via per-layer² sets of <code>L.Path</code> options in the <code
         // A function for styling features dynamically, depending on their
         // properties, the map&#39;s zoom level, and the layer's geometry
         // dimension (point, line, polygon)
-        water: function(properties, zoom, geometry_dimension) {
+        water: function(properties, zoom, geometryDimension) {
             return [
                 {   // point
                     radius: 5,

--- a/docs/vectorgrid-api-docs.html
+++ b/docs/vectorgrid-api-docs.html
@@ -366,7 +366,7 @@ Styling is done via per-layer² sets of <code>L.Path</code> options in the <code
 <pre><code class="lang-js">var vectorTileOptions = {
     vectorTileLayerStyles: {
         // A plain set of L.Path options.
-        water: {
+        landuse: {
             weight: 0,
             fillColor: &#39;#9bc2c4&#39;,
             fillOpacity: 1,
@@ -385,6 +385,29 @@ Styling is done via per-layer² sets of <code>L.Path</code> options in the <code
                 fillOpacity: 0
             }
         },
+        // A function for styling features dynamically, depending on their
+        // properties, the map&#39;s zoom level, and the layer's geometry type
+        // (point, line, polygon)
+        water: function(properties, zoom, type) {
+            return [
+                {   // point
+                    radius: 5,
+                    color: &#39;#cf52d3&#39;,
+                },
+                {   // line
+                    weight: 1,
+                    color: &#39;#cf52d3&#39;,
+                    dashArray: &#39;2, 6&#39;,
+                    fillOpacity: 0
+                },
+                {   // polygon
+                    weight: 1,
+                    fillColor: &#39;#9bc2c4&#39;,
+                    fillOpacity: 1,
+                    fill: true
+                }
+            ]
+        },
         // An &#39;icon&#39; option means that a L.Icon will be used
         place: {
             icon: new L.Icon.Default()
@@ -399,7 +422,7 @@ var pbfLayer = L.vectorGrid.protobuf(url, vectorTileOptions).addTo(map);
 <li>A set of <code>L.Path</code> options</li>
 <li>An array of sets of <code>L.Path</code> options</li>
 <li>A function that returns a set of <code>L.Path</code> options</li>
-<li>A function that returns an array of sets of <code>L.Path</code> options
+<li>A function that returns an array of sets of <code>L.Path</code> options for point, line, and polygon styles respectively
 <br>
 Layers² with no style specified will use the default <code>L.Path</code> options.
 <br>

--- a/src/Leaflet.VectorGrid.js
+++ b/src/Leaflet.VectorGrid.js
@@ -109,7 +109,12 @@ L.VectorGrid = L.GridLayer.extend({
 					var featureLayer = this._createLayer(feat, pxPerExtent);
 
 					for (var j = 0; j < styleOptions.length; j++) {
-						var style = L.extend({}, L.Path.prototype.options, styleOptions[j]);
+						if (styleOptions[j] instanceof Function) {
+							var styleOption = styleOptions[j](feat.properties, coords.z, feat.type);
+						} else {
+							var styleOption = styleOptions[j];
+						}
+						var style = L.extend({}, L.Path.prototype.options, styleOption);
 						featureLayer.render(renderer, style);
 						renderer._addPath(featureLayer);
 					}
@@ -196,7 +201,10 @@ L.VectorGrid = L.GridLayer.extend({
 		}
 
 		for (var j = 0; j < styleOptions.length; j++) {
-			var style = L.extend({}, L.Path.prototype.options, styleOptions[j]);
+			var styleOption = (styleOptions[j] instanceof Function) ?
+				styleOptions[j](feat.properties, renderer.getCoord().z, feat.type) :
+				styleOptions[j];
+			var style = L.extend({}, L.Path.prototype.options, styleOption);
 			feat.updateStyle(renderer, style);
 		}
 	},

--- a/src/Leaflet.VectorGrid.js
+++ b/src/Leaflet.VectorGrid.js
@@ -109,7 +109,12 @@ L.VectorGrid = L.GridLayer.extend({
 					var featureLayer = this._createLayer(feat, pxPerExtent);
 
 					for (var j = 0; j < styleOptions.length; j++) {
-						var style = L.extend({}, L.Path.prototype.options, styleOptions[j]);
+                        if (styleOptions[j] instanceof Function) {
+                            var styleOption = styleOptions[j](feat.properties, coords.z, feat.type);
+                        } else {
+                            var styleOption = styleOptions[j];
+                        }
+						var style = L.extend({}, L.Path.prototype.options, styleOption);
 						featureLayer.render(renderer, style);
 						renderer._addPath(featureLayer);
 					}
@@ -196,7 +201,10 @@ L.VectorGrid = L.GridLayer.extend({
 		}
 
 		for (var j = 0; j < styleOptions.length; j++) {
-			var style = L.extend({}, L.Path.prototype.options, styleOptions[j]);
+            var styleOption = (styleOptions[j] instanceof Function) ?
+                styleOptions[j](feat.properties, renderer.getCoord().z, feat.type) :
+                styleOptions[j];
+			var style = L.extend({}, L.Path.prototype.options, styleOption);
 			feat.updateStyle(renderer, style);
 		}
 	},

--- a/src/Leaflet.VectorGrid.js
+++ b/src/Leaflet.VectorGrid.js
@@ -95,7 +95,7 @@ L.VectorGrid = L.GridLayer.extend({
 					}
 
 					if (styleOptions instanceof Function) {
-						styleOptions = styleOptions(feat.properties, coords.z);
+						styleOptions = styleOptions(feat.properties, coords.z, feat.type);
 					}
 
 					if (!(styleOptions instanceof Array)) {
@@ -188,7 +188,7 @@ L.VectorGrid = L.GridLayer.extend({
 
 	_updateStyles: function(feat, renderer, styleOptions) {
 		styleOptions = (styleOptions instanceof Function) ?
-			styleOptions(feat.properties, renderer.getCoord().z) :
+			styleOptions(feat.properties, renderer.getCoord().z, feat.type) :
 			styleOptions;
 
 		if (!(styleOptions instanceof Array)) {

--- a/src/Leaflet.VectorGrid.js
+++ b/src/Leaflet.VectorGrid.js
@@ -109,11 +109,11 @@ L.VectorGrid = L.GridLayer.extend({
 					var featureLayer = this._createLayer(feat, pxPerExtent);
 
 					for (var j = 0; j < styleOptions.length; j++) {
-                        if (styleOptions[j] instanceof Function) {
-                            var styleOption = styleOptions[j](feat.properties, coords.z, feat.type);
-                        } else {
-                            var styleOption = styleOptions[j];
-                        }
+						if (styleOptions[j] instanceof Function) {
+							var styleOption = styleOptions[j](feat.properties, coords.z, feat.type);
+						} else {
+							var styleOption = styleOptions[j];
+						}
 						var style = L.extend({}, L.Path.prototype.options, styleOption);
 						featureLayer.render(renderer, style);
 						renderer._addPath(featureLayer);
@@ -201,9 +201,9 @@ L.VectorGrid = L.GridLayer.extend({
 		}
 
 		for (var j = 0; j < styleOptions.length; j++) {
-            var styleOption = (styleOptions[j] instanceof Function) ?
-                styleOptions[j](feat.properties, renderer.getCoord().z, feat.type) :
-                styleOptions[j];
+			var styleOption = (styleOptions[j] instanceof Function) ?
+				styleOptions[j](feat.properties, renderer.getCoord().z, feat.type) :
+				styleOptions[j];
 			var style = L.extend({}, L.Path.prototype.options, styleOption);
 			feat.updateStyle(renderer, style);
 		}

--- a/src/Leaflet.VectorGrid.js
+++ b/src/Leaflet.VectorGrid.js
@@ -109,12 +109,7 @@ L.VectorGrid = L.GridLayer.extend({
 					var featureLayer = this._createLayer(feat, pxPerExtent);
 
 					for (var j = 0; j < styleOptions.length; j++) {
-						if (styleOptions[j] instanceof Function) {
-							var styleOption = styleOptions[j](feat.properties, coords.z, feat.type);
-						} else {
-							var styleOption = styleOptions[j];
-						}
-						var style = L.extend({}, L.Path.prototype.options, styleOption);
+						var style = L.extend({}, L.Path.prototype.options, styleOptions[j]);
 						featureLayer.render(renderer, style);
 						renderer._addPath(featureLayer);
 					}
@@ -201,10 +196,7 @@ L.VectorGrid = L.GridLayer.extend({
 		}
 
 		for (var j = 0; j < styleOptions.length; j++) {
-			var styleOption = (styleOptions[j] instanceof Function) ?
-				styleOptions[j](feat.properties, renderer.getCoord().z, feat.type) :
-				styleOptions[j];
-			var style = L.extend({}, L.Path.prototype.options, styleOption);
+			var style = L.extend({}, L.Path.prototype.options, styleOptions[j]);
 			feat.updateStyle(renderer, style);
 		}
 	},


### PR DESCRIPTION
This then allows differentiation of styles with the same VT layer name.
Discussed here: https://github.com/Leaflet/Leaflet.VectorGrid/issues/125