### PR TITLE
Allow multiple features per ID per tile

### DIFF
--- a/src/Leaflet.VectorGrid.js
+++ b/src/Leaflet.VectorGrid.js
@@ -119,10 +119,16 @@ L.VectorGrid = L.GridLayer.extend({
 					}
 
 					if (storeFeatures) {
-						renderer._features[id] = {
+						// multiple features may share the same id, add them
+						// to an array of features
+						if (!renderer._features[id]) {
+							renderer._features[id] = [];
+						}
+
+						renderer._features[id].push({
 							layerName: layerName,
 							feature: featureLayer
-						};
+						});
 					}
 				}
 
@@ -144,17 +150,18 @@ L.VectorGrid = L.GridLayer.extend({
 
 		for (var tileKey in this._vectorTiles) {
 			var tile = this._vectorTiles[tileKey];
-			var features = tile._features;
-			var data = features[id];
-			if (data) {
-				var feat = data.feature;
+			var features = tile._features[id];
+			if (features) {
+				for (var i=0; i<features.length; i++) {
+                    var feature = features[i];
 
-				var styleOptions = layerStyle;
-				if (layerStyle[data.layerName]) {
-					styleOptions = layerStyle[data.layerName];
-				}
+                    var styleOptions = layerStyle;
+                    if (layerStyle[feature.layerName]) {
+                        styleOptions = layerStyle[feature.layerName];
+                    }
 
-				this._updateStyles(feat, tile, styleOptions);
+                    this._updateStyles(feature.feature, tile, styleOptions);
+                }
 			}
 		}
 		return this;
@@ -167,13 +174,15 @@ L.VectorGrid = L.GridLayer.extend({
 
 		for (var tileKey in this._vectorTiles) {
 			var tile = this._vectorTiles[tileKey];
-			var features = tile._features;
-			var data = features[id];
-			if (data) {
-				var feat = data.feature;
-				var styleOptions = this.options.vectorTileLayerStyles[ data.layerName ] ||
-				L.Path.prototype.options;
-				this._updateStyles(feat, tile, styleOptions);
+			var features = tile._features[id];
+			if (features) {
+				for (var i=0; i<features.length; i++) {
+					var feature = features[i];
+
+                    var styleOptions = this.options.vectorTileLayerStyles[feature.layerName] ||
+                        L.Path.prototype.options;
+                    this._updateStyles(feature.feature, tile, styleOptions);
+                }
 			}
 		}
 		return this;


### PR DESCRIPTION
Like #65, I was running into a case where only some features were getting updated with `setFeatureStyle` and `resetFeatureStyle`.

The underlying reason is addressed in this PR: there are multiple features that have the same ID in a given tile, but only the last encountered was stored with that ID (in `renderer._features[id]`).

I changed this to allow an array instead of a single feature and updated `setFeatureStyle` and `resetFeatureStyle` to use this.  It fixed my particular case.

(not sure what is going on here with whitespace, it looks right in my editor.  Sorry for any formatting issues)