### PR TITLE
Use _map._animateToZoom only if zoom is animating in _isCurrentTile

### DIFF
--- a/src/Leaflet.VectorGrid.Protobuf.js
+++ b/src/Leaflet.VectorGrid.Protobuf.js
@@ -92,7 +92,7 @@ L.VectorGrid.Protobuf = L.VectorGrid.extend({
 			return true;
 		}
 
-		var zoom = this._map._animateToZoom || this._map._zoom;
+		var zoom = this._map._animatingZoom ? this._map._animateToZoom : this._map._zoom;
 		var currentZoom = zoom === coords.z;
 
 		var tileBounds = this._tileCoordsToBounds(coords);


### PR DESCRIPTION
Map property _animateToZoom is not reset after animation, so _isCurrentTile() check could return false after map.setView() without animation.
As I can see in Leaflet source, Map property _animatingZoom is truthy only if animating (reset in Map._onZoomTransitionEnd) so we can rely on it when checking _isCurrentTile().