### PR TITLE
Use _fakeStop when present instead of fakeStop for older versions of Leaflet.

### DIFF
--- a/src/Leaflet.Renderer.Canvas.Tile.js
+++ b/src/Leaflet.Renderer.Canvas.Tile.js
@@ -52,7 +52,9 @@ L.Canvas.Tile = L.Canvas.extend({
 			}
 		}
 		if (clickedLayer)  {
-			L.DomEvent.fakeStop(e);
+			// For Leaflet versions < 1.1.0, use _fakeStop.
+			var fakeStop = L.DomEvent._fakeStop || L.DomEvent.fakeStop;
+			fakeStop(e);
 			this._fireEvent([clickedLayer], e);
 		}
 	},


### PR DESCRIPTION
Checks for presence of old `_fakeStop` method. If it's available, use it instead. If not, use the new `fakeStop`.