### PR TITLE
Fix missing latlng on mouse event in latest leaflet version

### DIFF
--- a/src/Leaflet.Renderer.Canvas.Tile.js
+++ b/src/Leaflet.Renderer.Canvas.Tile.js
@@ -53,6 +53,9 @@ L.Canvas.Tile = L.Canvas.extend({
 		}
 		if (clickedLayer)  {
 			L.DomEvent.fakeStop(e);
+			if (!layer.getLatLng()) {
+				layer.setLatLng(this._map.unproject(point));
+			}
 			this._fireEvent([clickedLayer], e);
 		}
 	},
@@ -95,4 +98,3 @@ L.Canvas.Tile = L.Canvas.extend({
 L.canvas.tile = function(tileCoord, tileSize, opts){
 	return new L.Canvas.Tile(tileCoord, tileSize, opts);
 }
-


### PR DESCRIPTION
The project doesn't seem properly maintained for now, but I'm using it and this PR allows fixing bugs in click events when using latest leaflet versions and canvas renderer.

Here for sake of people needing it, just in case.